### PR TITLE
edit Clevo N850EZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ TBD.
 
 | Model | Category | BootGuard | Manufactoring mode | ME version | Firmware version | coreboot support |
 |:------|:--------:|:---------:|:------------------:|:----------:|:----------------:|:----------------:|
-| N850EZ (Tuxedo Book BC1507) | Notebook | Yes | Yes | 12.0.6 | 1.07.08 | No |
+| N850EZ (Tuxedo Book BC1507) | Notebook | No(?) | No | 12.0.6 | 1.07.08 | No |
 
 ## Dell
 


### PR DESCRIPTION
after verification of the ME and bootguard status with "meinfo -FWSTS" (Part of the Intel System Tools) it became apparent that the ME is in "Productive" mode and the manufacturing mode is disabled