### PR TITLE
Add Sophos XG330r2

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ TBD.
 |:------|:--------:|:---------:|:------------------:|:----------------:|
 | FW6   | SBC      | No        | Yes                | Yes              |
 
+## Sophos (Caswell)
+
+| Model                  | Category                   | BootGuard | Manufactoring mode | coreboot support |
+|:-----------------------|:--------------------------:|:---------:|:------------------:|:----------------:|
+| XG330r2 (AIA-5276-EK)  | Network appliance / Server | No        | Yes                | No               |
 
 ## Supermicro
 


### PR DESCRIPTION
Add Sophos XG330r2 (Caswell motherboard model AIA-5276-EK)

```
# ./intelmetool -b
Bad news, you have a `Q170 Chipset LPC/eSPI Controller` so you have ME hardware on board and you can't control or disable it, continuing...

MEI found: [8086:a13a] 100 Series/C230 Series Chipset Family MEI Controller #1

ME Status   : 0x90000255
ME Status 2 : 0x6600850e

ME: FW Partition Table      : OK
ME: Bringup Loader Failure  : NO
ME: Firmware Init Complete  : YES
ME: Manufacturing Mode      : YES
ME: Boot Options Present    : NO
ME: Update In Progress      : NO
ME: Current Working State   : Normal
ME: Current Operation State : M0 with UMA
ME: Current Operation Mode  : Normal
ME: Error Code              : No Error
ME: Progress Phase          : Host Communication
ME: Power Management Event  : Pseudo-global reset
ME: Progress Phase State    : Host communication established

ME: Extend Register not valid

ME: Firmware Version 11.0.1191.0 (code) 11.0.1191.0 (recovery) 11.0.1191.0 (fitc)

ME Capability: Full Network manageability                 : OFF
ME Capability: Regular Network manageability              : OFF
ME Capability: Manageability                              : OFF
ME Capability: Small business technology                  : OFF
ME Capability: Level III manageability                    : OFF
ME Capability: IntelR Anti-Theft (AT)                     : OFF
ME Capability: IntelR Capability Licensing Service (CLS)  : ON
ME Capability: IntelR Power Sharing Technology (MPC)      : OFF
ME Capability: ICC Over Clocking                          : ON
ME Capability: Protected Audio Video Path (PAVP)          : ON
ME Capability: IPV6                                       : OFF
ME Capability: KVM Remote Control (KVM)                   : OFF
ME Capability: Outbreak Containment Heuristic (OCH)       : OFF
ME Capability: Virtual LAN (VLAN)                         : ON
ME Capability: TLS                                        : OFF
ME Capability: Wireless LAN (WLAN)                        : OFF
Bad news, you have a `Q170 Chipset LPC/eSPI Controller` so you have ME hardware on board and you can't control or disable it, continuing...

Your southbridge configuration is insecure!!
Boot Guard keys can be overwritten or wiped, or you are in developer mode.
Boot Guard MSR Output : 0x0
Your system isn't Boot Guard ready.
You can flash other firmware!
```

```
# dmidecode -t2
# dmidecode 3.4
Getting SMBIOS data from sysfs.
SMBIOS 3.0.0 present.

Handle 0x0002, DMI type 2, 15 bytes
Base Board Information
        Manufacturer: Sophos
        Product Name: XG
        Version: 330r2
        Serial Number: Default string
        Asset Tag: Default string
        Features:
                Board is a hosting board
                Board is replaceable
        Location In Chassis: Default string
        Chassis Handle: 0x0003
        Type: Motherboard
        Contained Object Handles: 0
```
