### PR TITLE
Add HP Elitedesk 800 G2 SFF to list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ TBD.
 | GA-Z170N-WIFI     | Desktop            | Yes       | Yes                | No               |
 | GA-Z170X-Gaming 7 | Desktop            | Yes       | Yes                | No               |
 | GA-SBCAP3450      | Desktop (Embedded) | Yes       | Yes                | No               |
+| GA-B250M-DS3H     | Desktop            | No        | Yes                | No               |
 
 ## GPD
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ TBD.
 |:---------|:--------:|:---------:|:------------------:|:----------------:|
 | Pocket 2 | Notebook | Yes       | Yes                | No               |
 
+## HP (Hewlett-Packard)
+
+| Model                | Category | BootGuard | Manufactoring mode | coreboot support |
+|:---------------------|:--------:|:---------:|:------------------:|:----------------:|
+| Elitedesk 800 G2 SFF | Desktop  | No        | Unknown            | No               |
+
 ## Lenovo
 
 | Model           | Category  | BootGuard | Manufactoring mode | coreboot support |


### PR DESCRIPTION
Bad news, you have a `Q170 Chipset LPC/eSPI Controller` so you have ME hardware on board and you can't control or disable it, continuing...

MEI found: [8086:a13a] 100 Series/C230 Series Chipset Family MEI Controller #1

ME Status   : 0x90000245
ME Status 2 : 0x89108106

ME: FW Partition Table      : OK
ME: Bringup Loader Failure  : NO
ME: Firmware Init Complete  : YES
ME: Manufacturing Mode      : NO
ME: Boot Options Present    : NO
ME: Update In Progress      : NO
ME: Current Working State   : Normal
ME: Current Operation State : M0 with UMA
ME: Current Operation Mode  : Normal
ME: Error Code              : No Error
ME: Progress Phase          : Clean Moff->Mx wake
ME: Power Management Event  : Non-power cycle reset
ME: Progress Phase State    : Unknown 0x10

ME: Extend Register not valid

ME: Firmware Version 11.8.4323.93 (code) 11.8.4323.93 (recovery) 11.0.1205.0 (fitc)

ME Capability: Full Network manageability                 : ON
ME Capability: Regular Network manageability              : ON
ME Capability: Manageability                              : ON
ME Capability: Small business technology                  : OFF
ME Capability: Level III manageability                    : OFF
ME Capability: IntelR Anti-Theft (AT)                     : OFF
ME Capability: IntelR Capability Licensing Service (CLS)  : ON
ME Capability: IntelR Power Sharing Technology (MPC)      : OFF
ME Capability: ICC Over Clocking                          : OFF
ME Capability: Protected Audio Video Path (PAVP)          : ON
ME Capability: IPV6                                       : ON
ME Capability: KVM Remote Control (KVM)                   : ON
ME Capability: Outbreak Containment Heuristic (OCH)       : ON
ME Capability: Virtual LAN (VLAN)                         : ON
ME Capability: TLS                                        : ON
ME Capability: Wireless LAN (WLAN)                        : ON
Bad news, you have a `Q170 Chipset LPC/eSPI Controller` so you have ME hardware on board and you can't control or disable it, continuing...

Boot Guard MSR Output : 0x0
Your system isn't Boot Guard ready.
You can flash other firmware!

On board there is unpopulated ME_DEBUG Header which may enable Manufacturing Mode.